### PR TITLE
Refactor parsing state

### DIFF
--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -12,6 +12,8 @@ using System.Windows.Forms;
 using gMKVToolNix.Jobs;
 using gMKVToolNix.Log;
 using gMKVToolNix.MkvExtract;
+using gMKVToolNix.MkvInfo;
+using gMKVToolNix.MkvMerge;
 using gMKVToolNix.Segments;
 using gMKVToolNix.Theming;
 using gMKVToolNix.WinAPI;
@@ -632,8 +634,10 @@ namespace gMKVToolNix.Forms
             {
                 tlpMain.Enabled = false;
                 Application.DoEvents();
+
                 // empty all the controls in any case
                 ClearControls();
+
                 // Check for append file or not
                 if (!argAppend)
                 {
@@ -679,6 +683,7 @@ namespace gMKVToolNix.Forms
 
                 // Add the nodes to the TreeView
                 trvInputFiles.Nodes.AddRange(results.Nodes.ToArray());
+
                 // Remove the check box from the nodes that contain the gMKVSegmentInfo
                 trvInputFiles.AllNodes.Where(n => n != null && n.Tag != null && n.Tag is gMKVSegmentInfo)
                     .ToList()
@@ -711,6 +716,9 @@ namespace gMKVToolNix.Forms
             NodeResults results = new NodeResults();
             List<TreeNode> fileNodes = new List<TreeNode>();
 
+            gMKVMerge gMerge = new gMKVMerge(argMKVToolNixPath);
+            gMKVInfo gInfo = new gMKVInfo(argMKVToolNixPath);
+
             statusStrip.Invoke((MethodInvoker)delegate
             {
                 prgBrStatus.Maximum = argFiles.Count;
@@ -734,7 +742,7 @@ namespace gMKVToolNix.Forms
 
                 try
                 {
-                    fileNodes.Add(GetFileNode(argMKVToolNixPath, sf));
+                    fileNodes.Add(GetFileNode(gMerge, gInfo, sf));
                 }
                 catch (Exception ex)
                 {
@@ -751,14 +759,8 @@ namespace gMKVToolNix.Forms
             return results;
         }
 
-        private TreeNode GetFileNode(string argMKVToolNixPath, string argFilename)
+        private TreeNode GetFileNode(gMKVMerge gMerge, gMKVInfo gInfo, string argFilename)
         {
-            // Check if MKVToolNix path was provided
-            if (string.IsNullOrWhiteSpace(argMKVToolNixPath))
-            {
-                throw new Exception("The MKVToolNix path was not provided!");
-            }
-
             // Check if filename was provided
             if (string.IsNullOrWhiteSpace(argFilename))
             {
@@ -782,8 +784,8 @@ namespace gMKVToolNix.Forms
                 throw new Exception($"The input file {argFilename}{Environment.NewLine}{Environment.NewLine}is not a valid matroska file!");
             }
 
-            // get the file information                    
-            List<gMKVSegment> segmentList = gMKVHelper.GetMergedMkvSegmentList(argMKVToolNixPath, argFilename);
+            // get the file information
+            List<gMKVSegment> segmentList = gMKVHelper.GetMergedMkvSegmentList(gMerge, gInfo, argFilename);
 
             gMKVSegmentInfo segInfo = segmentList.OfType<gMKVSegmentInfo>().FirstOrDefault();
 

--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -471,38 +471,30 @@ namespace gMKVToolNix.Forms
                     Cursor = Cursors.Default;
                     var result = ShowQuestion("Do you want to include files in sub directories?", "Sub directories found!");
                     Cursor = Cursors.WaitCursor;
-                    if (result == DialogResult.Yes)
-                    {
-                        using (Task ta = Task.Factory.StartNew(() =>
-                        {
-                            // Add the subdirectory files
-                            argFileDrop.Where(f => Directory.Exists(f))
-                            .ToList()
-                            .ForEach(t => fileList.AddRange(Directory.GetFiles(t, "*", SearchOption.AllDirectories).ToList()));
-                        }))
-                        {
-                            while (!ta.IsCompleted) { Application.DoEvents(); }
-                            if (ta.Exception != null) { throw ta.Exception; }
-                        }
-                    }
-                    else if (result == DialogResult.No)
-                    {
-                        using (Task ta = Task.Factory.StartNew(() =>
-                        {
-                            // Add the top level directory files
-                            argFileDrop.Where(f => Directory.Exists(f))
-                            .ToList()
-                            .ForEach(t => fileList.AddRange(Directory.GetFiles(t, "*", SearchOption.TopDirectoryOnly).ToList()));
-                        }))
-                        {
-                            while (!ta.IsCompleted) { Application.DoEvents(); }
-                            if (ta.Exception != null) { throw ta.Exception; }
-                        }
-                    }
-                    else if (result == DialogResult.Cancel)
+
+                    if (result == DialogResult.Cancel)
                     {
                         Cursor = Cursors.Default;
                         return new List<string>();
+                    }
+
+                    using (Task ta = Task.Factory.StartNew(() =>
+                    {
+                        // Add the subdirectory files
+                        argFileDrop.Where(f => Directory
+                            .Exists(f))
+                            .ToList()
+                            .ForEach(t => fileList.AddRange(Directory.GetFiles(
+                                t, 
+                                "*", 
+                                result == DialogResult.Yes 
+                                    ? SearchOption.AllDirectories
+                                    : SearchOption.TopDirectoryOnly)
+                            .ToList()));
+                    }))
+                    {
+                        while (!ta.IsCompleted) { Application.DoEvents(); }
+                        if (ta.Exception != null) { throw ta.Exception; }
                     }
                 }
                 else

--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -766,7 +766,7 @@ namespace gMKVToolNix.Forms
             }
 
             // Check if the extension is a valid matroska file
-            string inputExtension = Path.GetExtension(argFilename).ToLower();
+            string inputExtension = Path.GetExtension(argFilename).ToLowerInvariant();
             if (inputExtension != ".mkv"
                 && inputExtension != ".mka"
                 && inputExtension != ".mks"
@@ -809,6 +809,7 @@ namespace gMKVToolNix.Forms
                     {
                         throw new Exception("Selected node has null tag!");
                     }
+
                     if (!(selNode.Tag is gMKVSegmentInfo))
                     {
                         // Get parent node
@@ -817,15 +818,18 @@ namespace gMKVToolNix.Forms
                         {
                             throw new Exception("Selected node has no parent node!");
                         }
+
                         if (selNode.Tag == null)
                         {
                             throw new Exception("Selected node has null tag!");
                         }
+
                         if (!(selNode.Tag is gMKVSegmentInfo))
                         {
                             throw new Exception("Selected node has no info!");
                         }
                     }
+
                     gMKVSegmentInfo seg = selNode.Tag as gMKVSegmentInfo;
                     txtSegmentInfo.Text = string.Format("Writing Application: {1}{0}Muxing Application: {2}{0}Duration: {3}{0}Date: {4}",
                         Environment.NewLine,
@@ -894,27 +898,16 @@ namespace gMKVToolNix.Forms
             {
                 throw new Exception("You must provide with MKVToolnix path!");
             }
+
             if (!File.Exists(Path.Combine(txtMKVToolnixPath.Text.Trim(), gMKVHelper.MKV_MERGE_GUI_FILENAME))
                 && !File.Exists(Path.Combine(txtMKVToolnixPath.Text.Trim(), gMKVHelper.MKV_MERGE_NEW_GUI_FILENAME)))
             {
                 throw new Exception("The MKVToolnix path provided does not contain MKVToolnix files!");
             }
+
             if (!chkUseSourceDirectory.Checked && string.IsNullOrWhiteSpace(txtOutputDirectory.Text))
             {
                 throw new Exception("You haven't specified an output directory!");
-            }
-            if (!chkUseSourceDirectory.Checked && !Directory.Exists(txtOutputDirectory.Text.Trim()))
-            {
-                // Ask the user to create the non existing output directory
-                if (ShowQuestion(string.Format("The output directory \"{0}\" does not exist!{1}{1}Do you want to create it?", txtOutputDirectory.Text.Trim(), Environment.NewLine), "Output directory does not exist!", false) != DialogResult.Yes)
-                {
-                    throw new Exception(string.Format("The output directory \"{0}\" does not exist!{1}{1}Extraction was cancelled!", txtOutputDirectory.Text.Trim(), Environment.NewLine));
-                }
-                else
-                {
-                    // Create the non existing output directory
-                    Directory.CreateDirectory(txtOutputDirectory.Text.Trim());
-                }
             }
 
             // Get the checked nodes
@@ -922,7 +915,9 @@ namespace gMKVToolNix.Forms
 
             if (checkSelectedTracks)
             {
-                FormMkvExtractionMode selectedExtractionMode = (FormMkvExtractionMode)Enum.Parse(typeof(FormMkvExtractionMode), (string)cmbExtractionMode.SelectedItem);
+                FormMkvExtractionMode selectedExtractionMode = (FormMkvExtractionMode)Enum.Parse(
+                    typeof(FormMkvExtractionMode), 
+                    (string)cmbExtractionMode.SelectedItem);
 
                 // Check if the checked nodes contain tracks
                 if (!checkedNodes.Any(t => t.Tag != null && !(t.Tag is gMKVSegmentInfo)))
@@ -970,6 +965,20 @@ namespace gMKVToolNix.Forms
                     }
                 }
             }
+
+            if (!chkUseSourceDirectory.Checked && !Directory.Exists(txtOutputDirectory.Text.Trim()))
+            {
+                // Ask the user to create the non existing output directory
+                if (ShowQuestion(string.Format("The output directory \"{0}\" does not exist!{1}{1}Do you want to create it?", txtOutputDirectory.Text.Trim(), Environment.NewLine), "Output directory does not exist!", false) != DialogResult.Yes)
+                {
+                    throw new Exception(string.Format("The output directory \"{0}\" does not exist!{1}{1}Extraction was cancelled!", txtOutputDirectory.Text.Trim(), Environment.NewLine));
+                }
+                else
+                {
+                    // Create the non existing output directory
+                    Directory.CreateDirectory(txtOutputDirectory.Text.Trim());
+                }
+            }
         }
 
         private gMKVExtractFilenamePatterns GetFilenamePatterns()
@@ -1013,7 +1022,9 @@ namespace gMKVToolNix.Forms
                 _gMkvExtract.MkvExtractProgressUpdated += g_MkvExtractProgressUpdated;
                 _gMkvExtract.MkvExtractTrackUpdated += g_MkvExtractTrackUpdated;
 
-                FormMkvExtractionMode extractionMode = (FormMkvExtractionMode)Enum.Parse(typeof(FormMkvExtractionMode), (string)cmbExtractionMode.SelectedItem);
+                FormMkvExtractionMode extractionMode = (FormMkvExtractionMode)Enum.Parse(
+                    typeof(FormMkvExtractionMode), 
+                    (string)cmbExtractionMode.SelectedItem);
 
                 // Check for necessary input fields 
                 switch (extractionMode)
@@ -1066,11 +1077,13 @@ namespace gMKVToolNix.Forms
                     gMKVSegmentInfo infoSegment = parentNode.Tag as gMKVSegmentInfo;
                     segments = checkedNodes.Where(n => n.Parent == parentNode).Select(t => t.Tag as gMKVSegment).ToList();
                     string outputDirectory = txtOutputDirectory.Text;
+                    
                     // Check if the output dir is the same as the source
                     if (chkUseSourceDirectory.Checked)
                     {
                         outputDirectory = infoSegment.Directory;
                     }
+
                     gMKVExtractSegmentsParameters parameterList = new gMKVExtractSegmentsParameters();
                     switch (extractionMode)
                     {
@@ -1148,6 +1161,7 @@ namespace gMKVToolNix.Forms
                     {
                         _JobManagerForm = new frmJobManager(this);
                     }
+
                     _JobManagerForm.Show();
                     foreach (var job in jobs)
                     {
@@ -1189,10 +1203,12 @@ namespace gMKVToolNix.Forms
                         }
                         UpdateProgress(100);
                     }
+
                     btnAbort.Enabled = false;
                     btnAbortAll.Enabled = false;
                     this.Refresh();
                     Application.DoEvents();
+
                     if (chkShowPopup.Checked)
                     {
                         ShowSuccessMessage("The extraction was completed successfully!", true);
@@ -1295,6 +1311,7 @@ namespace gMKVToolNix.Forms
                     gMKVLogger.Log($"Changing MkvToolnixPath to {trimmedPath}");
                     _Settings.Save();
                 }
+
                 _gMkvExtract = new gMKVExtract(txtMKVToolnixPath.Text);
             }
             catch (Exception ex)
@@ -1362,6 +1379,7 @@ namespace gMKVToolNix.Forms
             {
                 txtOutputDirectory.ReadOnly = chkUseSourceDirectory.Checked;
                 btnBrowseOutputDirectory.Enabled = !chkUseSourceDirectory.Checked;
+
                 if (!_FromConstructor)
                 {
                     _Settings.LockedOutputDirectory = chkUseSourceDirectory.Checked;
@@ -1393,7 +1411,7 @@ namespace gMKVToolNix.Forms
                         FileName = "Select directory",
                         Title = "Select output directory..."
                     };
-                    if (sfd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    if (sfd.ShowDialog() == DialogResult.OK)
                     {
                         txtOutputDirectory.Text = Path.GetDirectoryName(sfd.FileName);
                     }
@@ -1428,6 +1446,7 @@ namespace gMKVToolNix.Forms
                     FileName = "Select directory",
                     Title = "Select MKVToolnix directory..."
                 };
+
                 if (!string.IsNullOrWhiteSpace(txtMKVToolnixPath.Text))
                 {
                     if (Directory.Exists(txtMKVToolnixPath.Text.Trim()))
@@ -1435,7 +1454,8 @@ namespace gMKVToolNix.Forms
                         ofd.InitialDirectory = txtMKVToolnixPath.Text.Trim();
                     }
                 }
-                if (ofd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+
+                if (ofd.ShowDialog() == DialogResult.OK)
                 {
                     txtMKVToolnixPath.Text = Path.GetDirectoryName(ofd.FileName);
                 }
@@ -1456,6 +1476,7 @@ namespace gMKVToolNix.Forms
                 {
                     _LogForm = new frmLog();
                 }
+
                 _LogForm.Show();
                 _LogForm.Focus();
                 _LogForm.Select();
@@ -1476,6 +1497,7 @@ namespace gMKVToolNix.Forms
                 {
                     _JobManagerForm = new frmJobManager(this);
                 }
+
                 _JobManagerForm.Show();
                 _JobManagerForm.Focus();
                 _JobManagerForm.Select();
@@ -2236,6 +2258,7 @@ namespace gMKVToolNix.Forms
 
                     break;
             }
+
             nodes.ForEach(n => n.Checked = argCheck);
         }
 
@@ -2322,11 +2345,13 @@ namespace gMKVToolNix.Forms
             {
                 return;
             }
+
             TreeNode node = trvInputFiles.SelectedNode;
             if (!(node.Tag is gMKVSegmentInfo))
             {
                 node = node.Parent;
             }
+
             trvInputFiles.Nodes.Remove(node);
             if (trvInputFiles.Nodes.Count > 0)
             {
@@ -2348,11 +2373,13 @@ namespace gMKVToolNix.Forms
                 {
                     return;
                 }
+
                 TreeNode node = trvInputFiles.SelectedNode;
                 if (!(node.Tag is gMKVSegmentInfo))
                 {
                     node = node.Parent;
                 }
+
                 gMKVSegmentInfo segInfo = node.Tag as gMKVSegmentInfo;
                 if (File.Exists(segInfo.Path))
                 {
@@ -2375,13 +2402,14 @@ namespace gMKVToolNix.Forms
                 {
                     return;
                 }
+
                 TreeNode node = trvInputFiles.SelectedNode;
                 if (!(node.Tag is gMKVSegmentInfo))
                 {
                     node = node.Parent;
                 }
-                gMKVSegmentInfo segInfo = node.Tag as gMKVSegmentInfo;
 
+                gMKVSegmentInfo segInfo = node.Tag as gMKVSegmentInfo;
                 if (Directory.Exists(segInfo.Directory))
                 {
                     if (File.Exists(segInfo.Path))
@@ -2413,7 +2441,8 @@ namespace gMKVToolNix.Forms
                     Multiselect = true,
                     AutoUpgradeEnabled = true
                 };
-                if (ofd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+
+                if (ofd.ShowDialog() == DialogResult.OK)
                 {
                     AddFileNodes(txtMKVToolnixPath.Text, new List<string>(ofd.FileNames), true);
                 }
@@ -2492,6 +2521,7 @@ namespace gMKVToolNix.Forms
                             return;
                         }
                     }
+
                     _Settings.DefaultOutputDirectory = txtOutputDirectory.Text.Trim();
                     gMKVLogger.Log("Changing Default Output Directory...");
                     _Settings.Save();
@@ -2552,11 +2582,13 @@ namespace gMKVToolNix.Forms
                 _Settings.DarkMode = chkDarkMode.Checked;
                 _Settings.Save();
                 ThemeManager.ApplyTheme(this, _Settings.DarkMode); // Apply theme on toggle
+
                 // Hack for DarkMode checkbox
                 if (_Settings.DarkMode)
                 {
                     chkDarkMode.BackColor = Color.FromArgb(55, 55, 55);
                 }
+
                 NativeMethods.SetWindowThemeManaged(this.Handle, _Settings.DarkMode);
                 NativeMethods.TrySetImmersiveDarkMode(this.Handle, _Settings.DarkMode);
 

--- a/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 using gMKVToolNix.Log;
@@ -15,19 +14,6 @@ namespace gMKVToolNix.MkvExtract
 
     public class gMKVExtract
     {
-        private class OptionValue
-        {
-            public MkvExtractGlobalOptions Option { get; set; }
-
-            public string Parameter { get; set; } = "";
-
-            public OptionValue(MkvExtractGlobalOptions option, string parameter)
-            {
-                Option = option;
-                Parameter = parameter;
-            }
-        }
-
         /// <summary>
         /// Gets the mkvextract executable filename
         /// </summary>
@@ -782,9 +768,9 @@ namespace gMKVToolNix.MkvExtract
                 // When on Linux, we need to run mkvextract
 
                 // Execute mkvextract
-                List<OptionValue> options = new List<OptionValue>
+                List<OptionValue<MkvExtractGlobalOptions>> options = new List<OptionValue<MkvExtractGlobalOptions>>
                 {
-                    new OptionValue(MkvExtractGlobalOptions.version, "")
+                    new OptionValue<MkvExtractGlobalOptions>(MkvExtractGlobalOptions.version, "")
                 };
 
                 List<string> versionOutputLines = new List<string>();
@@ -794,12 +780,12 @@ namespace gMKVToolNix.MkvExtract
                 {
                     // if on Linux, the language output must be defined from the environment variables LC_ALL, LANG, and LC_MESSAGES
                     // After talking with Mosu, the language output is defined from ui-language, with different language codes for Windows and Linux
-                    options.Add(new OptionValue(MkvExtractGlobalOptions.ui_language, "en_US"));
+                    options.Add(new OptionValue<MkvExtractGlobalOptions>(MkvExtractGlobalOptions.ui_language, "en_US"));
 
                     ProcessStartInfo myProcessInfo = new ProcessStartInfo
                     {
                         FileName = _MKVExtractFilename,
-                        Arguments = ConvertOptionValueListToString(options),
+                        Arguments = options.ConvertOptionValueListToString(),
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
                         StandardOutputEncoding = Encoding.UTF8,
@@ -916,36 +902,6 @@ namespace gMKVToolNix.MkvExtract
             {
                 errorAction(lineReceived.Substring(lineReceived.IndexOf(":") + 1).Trim());
             }
-        }
-
-        private static string ConvertOptionValueListToString(List<OptionValue> listOptionValue)
-        {
-            StringBuilder optionString = new StringBuilder();
-            foreach (OptionValue optVal in listOptionValue)
-            {
-                optionString.Append(' ');
-                optionString.Append(ConvertEnumOptionToStringOption(optVal.Option));
-                if (!string.IsNullOrWhiteSpace(optVal.Parameter))
-                {
-                    optionString.Append(' ');
-                    optionString.Append(optVal.Parameter);
-                }
-            }
-
-            return optionString.ToString();
-        }
-
-        private static readonly Dictionary<MkvExtractGlobalOptions, string> _MkvExtractGlobalOptionsToStringMap = 
-            Enum.GetValues(typeof(MkvExtractGlobalOptions))
-            .Cast<MkvExtractGlobalOptions>()
-            .ToDictionary(
-                val => val,
-                val => $"--{val.ToString().Replace("_", "-")}"
-            );
-
-        private static string ConvertEnumOptionToStringOption(MkvExtractGlobalOptions enumOption)
-        {
-            return _MkvExtractGlobalOptionsToStringMap[enumOption];
         }
     }
 }

--- a/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
@@ -624,12 +624,6 @@ namespace gMKVToolNix.MkvExtract
         {
             OnMkvExtractProgressUpdated(0);
 
-            // check for existence of MKVExtract
-            if (!File.Exists(_MKVExtractFilename))
-            {
-                throw new Exception($"Could not find {MKV_EXTRACT_FILENAME}!{Environment.NewLine}{_MKVExtractFilename}");
-            }
-
             Action<Process, string> handler = null;
 
             // Since MKVToolNix v17.0, items that were written to the standard output (chapters, tags and cue sheets)

--- a/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
@@ -189,7 +189,8 @@ namespace gMKVToolNix.MkvExtract
                         // If we have chapters with CUE or PBF format, then we read the XML chapters and convert it to CUE or PBF format
                         if (finalPar.ExtractMode == MkvExtractModes.chapters)
                         {
-                            // Since MKVToolNix v17.0, items that were written to the standard output (chapters, tags and cue sheets) are now always written to files instead.
+                            // Since MKVToolNix v17.0, items that were written to the standard output (chapters, tags and cue sheets)
+                            // are now always written to files instead.
                             string outputFile = _Version.FileMajorPart >= 17 
                                 ? finalPar.TrackOutput 
                                 : finalPar.OutputFilename;
@@ -308,7 +309,12 @@ namespace gMKVToolNix.MkvExtract
             Abort = false;
             AbortAll = false;
 
-            string cueFile = gMKVExtractExtensions.GetOutputFilename(null, argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.cuesheet);
+            string cueFile = gMKVExtractExtensions.GetOutputFilename(
+                null, 
+                argOutputDirectory, 
+                argMKVFile, 
+                argFilenamePatterns, 
+                MkvExtractModes.cuesheet);
 
             List<string> errors = new List<string>();
             StreamWriter outputFileWriter = null;
@@ -378,7 +384,12 @@ namespace gMKVToolNix.MkvExtract
             Abort = false;
             AbortAll = false;
 
-            string tagsFile = gMKVExtractExtensions.GetOutputFilename(null, argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.tags);
+            string tagsFile = gMKVExtractExtensions.GetOutputFilename(
+                null, 
+                argOutputDirectory, 
+                argMKVFile, 
+                argFilenamePatterns, 
+                MkvExtractModes.tags);
 
             List<string> errors = new List<string>();
             StreamWriter outputFileWriter = null;
@@ -460,7 +471,11 @@ namespace gMKVToolNix.MkvExtract
                         "",
                         string.Format("{0}:\"{1}\"",
                             track.TrackID,
-                            argSeg.GetOutputFilename(argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.timestamps_v2)
+                            argSeg.GetOutputFilename(
+                                argOutputDirectory, 
+                                argMKVFile, 
+                                argFilenamePatterns, 
+                                MkvExtractModes.timestamps_v2)
                         ),
                         false,
                         ""
@@ -475,7 +490,11 @@ namespace gMKVToolNix.MkvExtract
                         "",
                         string.Format("{0}:\"{1}\"",
                             track.TrackID,
-                            argSeg.GetOutputFilename(argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.cues)
+                            argSeg.GetOutputFilename(
+                                argOutputDirectory, 
+                                argMKVFile, 
+                                argFilenamePatterns, 
+                                MkvExtractModes.cues)
                         ),
                         false,
                         ""
@@ -504,7 +523,11 @@ namespace gMKVToolNix.MkvExtract
                         "",
                         string.Format("{0}:\"{1}\"",
                             track.TrackID,
-                            argSeg.GetOutputFilename(argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.tracks)
+                            argSeg.GetOutputFilename(
+                                argOutputDirectory, 
+                                argMKVFile, 
+                                argFilenamePatterns, 
+                                MkvExtractModes.tracks)
                         ),
                         false,
                         ""
@@ -535,7 +558,11 @@ namespace gMKVToolNix.MkvExtract
                         "",
                         string.Format("{0}:\"{1}\"",
                             attachment.ID,
-                            argSeg.GetOutputFilename(argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.attachments)
+                            argSeg.GetOutputFilename(
+                                argOutputDirectory, 
+                                argMKVFile, 
+                                argFilenamePatterns, 
+                                MkvExtractModes.attachments)
                         ),
                         false,
                         ""
@@ -567,7 +594,12 @@ namespace gMKVToolNix.MkvExtract
                         options = "--simple";
                     }
 
-                    string chapterFile = argSeg.GetOutputFilename(argOutputDirectory, argMKVFile, argFilenamePatterns, MkvExtractModes.chapters, argChapterType);
+                    string chapterFile = argSeg.GetOutputFilename(
+                        argOutputDirectory, 
+                        argMKVFile, 
+                        argFilenamePatterns, 
+                        MkvExtractModes.chapters, 
+                        argChapterType);
 
                     // add the parameter for extracting the chapters
                     // Since MKVToolNix v17.0, items that were written to the standard output (chapters, tags and cue sheets) are now always written to files instead.
@@ -584,7 +616,11 @@ namespace gMKVToolNix.MkvExtract
             return trackParameterList;
         }
 
-        private void ExtractMkvSegment(string argMKVFile, TrackParameter argParameter, List<string> errors, StreamWriter argOutputFileWriter)
+        private void ExtractMkvSegment(
+            string argMKVFile, 
+            TrackParameter argParameter, 
+            List<string> errors, 
+            StreamWriter argOutputFileWriter)
         {
             OnMkvExtractProgressUpdated(0);
 
@@ -614,7 +650,11 @@ namespace gMKVToolNix.MkvExtract
             ExecuteMkvExtract(argMKVFile, argParameter, handler, errors);
         }
 
-        private void ExecuteMkvExtract(string argMKVFile, TrackParameter argParameter, Action<Process, string> argHandler, List<string> errors)
+        private void ExecuteMkvExtract(
+            string argMKVFile, 
+            TrackParameter argParameter, 
+            Action<Process, string> argHandler, 
+            List<string> errors)
         {
             using (Process myProcess = new Process())
             {
@@ -855,7 +895,7 @@ namespace gMKVToolNix.MkvExtract
             return (process, line) => ProcessLineReceivedHandler(process, line, outputAction, errorAction);
         }
 
-        void ProcessLineReceivedHandler(
+        private void ProcessLineReceivedHandler(
             Process senderProcess, 
             string lineReceived, 
             Action<string> outputAction,

--- a/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
+++ b/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
@@ -37,7 +37,6 @@ namespace gMKVToolNix.MkvInfo
         
         private readonly string _MKVToolnixPath = "";
         private readonly string _MKVInfoFilename = "";
-        private readonly List<gMKVSegment> _SegmentList = new List<gMKVSegment>();
         private readonly gMKVVersion _Version = null;
 
         public gMKVInfo(string mkvToolnixPath)
@@ -80,9 +79,7 @@ namespace gMKVToolNix.MkvInfo
                 throw new Exception($"Could not find {MKV_INFO_FILENAME}!{Environment.NewLine}{_MKVInfoFilename}");
             }
 
-            // First clear the segment list
-            _SegmentList.Clear();
-
+            List<gMKVSegment> segmentList = new List<gMKVSegment>();
             List<string> outputLines = new List<string>();
             List<string> errors = new List<string>();
 
@@ -92,17 +89,17 @@ namespace gMKVToolNix.MkvInfo
                 (string error) => errors.Add(error)));
 
             // Start the parsing of the output
-            ParseMkvInfoOutput(outputLines);
+            ParseMkvInfoOutput(outputLines, segmentList);
 
             // Add the file properties in gMKVSegmentInfo
-            var segInfo = _SegmentList.OfType<gMKVSegmentInfo>().FirstOrDefault();
+            var segInfo = segmentList.OfType<gMKVSegmentInfo>().FirstOrDefault();
             if (segInfo != null)
             {
                 segInfo.Directory = Path.GetDirectoryName(argMKVFile);
                 segInfo.Filename = Path.GetFileName(argMKVFile);
             }
 
-            return _SegmentList;
+            return segmentList;
         }
 
         public void FindAndSetDelays(List<gMKVSegment> argSegmentsList, string argMKVFile)
@@ -439,7 +436,7 @@ namespace gMKVToolNix.MkvInfo
             InsideChapterInfo,
         }
 
-        private void ParseMkvInfoOutput(List<string> outputLines)
+        private void ParseMkvInfoOutput(List<string> outputLines, List<gMKVSegment> segmentList)
         {
             // start the loop for each line of the output
             gMKVSegment tmpSegment = null;
@@ -465,7 +462,7 @@ namespace gMKVToolNix.MkvInfo
                     // if previous segment is not null, add it to the list and create a new one
                     if (tmpSegment != null)
                     {
-                        _SegmentList.Add(tmpSegment);
+                        segmentList.Add(tmpSegment);
                     }
                     tmpSegment = new gMKVSegmentInfo();
                     tmpState = MkvInfoParseState.InsideSegmentInfo;
@@ -541,7 +538,7 @@ namespace gMKVToolNix.MkvInfo
                             // if previous segment is not null, add it to the list and create a new one
                             if (tmpSegment != null)
                             {
-                                _SegmentList.Add(tmpSegment);
+                                segmentList.Add(tmpSegment);
                             }
                             tmpSegment = new gMKVTrack();
                         }
@@ -662,7 +659,7 @@ namespace gMKVToolNix.MkvInfo
                             // if previous segment is not null, add it to the list and create a new one
                             if (tmpSegment != null)
                             {
-                                _SegmentList.Add(tmpSegment);
+                                segmentList.Add(tmpSegment);
                             }
                             tmpSegment = new gMKVAttachment();
                             ((gMKVAttachment)tmpSegment).ID = attachmentID;
@@ -725,7 +722,7 @@ namespace gMKVToolNix.MkvInfo
                             // if previous segment is not null, add it to the list and create a new one
                             if (tmpSegment != null)
                             {
-                                _SegmentList.Add(tmpSegment);
+                                segmentList.Add(tmpSegment);
                             }
                             tmpSegment = new gMKVChapter();
                         }
@@ -785,7 +782,7 @@ namespace gMKVToolNix.MkvInfo
             // if the last segment was not added to the list and it is not null, add it to the list
             if (tmpSegment != null)
             {
-                _SegmentList.Add(tmpSegment);
+                segmentList.Add(tmpSegment);
             }
         }
 

--- a/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
+++ b/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
@@ -73,12 +73,6 @@ namespace gMKVToolNix.MkvInfo
 
         public List<gMKVSegment> GetMKVSegments(string argMKVFile)
         {
-            // Check for existence of MKVInfo
-            if (!File.Exists(_MKVInfoFilename))
-            {
-                throw new Exception($"Could not find {MKV_INFO_FILENAME}!{Environment.NewLine}{_MKVInfoFilename}");
-            }
-
             List<gMKVSegment> segmentList = new List<gMKVSegment>();
             List<string> outputLines = new List<string>();
             List<string> errors = new List<string>();
@@ -104,12 +98,6 @@ namespace gMKVToolNix.MkvInfo
 
         public void FindAndSetDelays(List<gMKVSegment> argSegmentsList, string argMKVFile)
         {
-            // check for existence of MKVInfo
-            if (!File.Exists(_MKVInfoFilename))
-            {
-                throw new Exception($"Could not find {MKV_INFO_FILENAME}!{Environment.NewLine}{_MKVInfoFilename}");
-            }
-
             // check for list of track numbers
             if (argSegmentsList == null || argSegmentsList.Count == 0)
             {

--- a/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
+++ b/src/gMKVToolNix/MkvInfo/gMKVInfo.cs
@@ -308,7 +308,11 @@ namespace gMKVToolNix.MkvInfo
             }
         }
 
-        private void ExecuteMkvInfo(List<OptionValue<MkvInfoOptions>> argOptionList, string argMKVFile, List<string> errors, Action<Process, string> argHandler)
+        private void ExecuteMkvInfo(
+            List<OptionValue<MkvInfoOptions>> argOptionList, 
+            string argMKVFile, 
+            List<string> errors, 
+            Action<Process, string> argHandler)
         {
             using (Process myProcess = new Process())
             {

--- a/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
+++ b/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
@@ -302,7 +302,11 @@ namespace gMKVToolNix.MkvMerge
             }
         }
 
-        private void ExecuteMkvMerge(List<OptionValue<MkvMergeOptions>> argOptionList, string argMKVFile, List<string> errors, Action<Process, string> argHandler)
+        private void ExecuteMkvMerge(
+            List<OptionValue<MkvMergeOptions>> argOptionList, 
+            string argMKVFile, 
+            List<string> errors, 
+            Action<Process, string> argHandler)
         {
             using (Process myProcess = new Process())
             {
@@ -1105,7 +1109,11 @@ namespace gMKVToolNix.MkvMerge
             return (process, line) => ProcessLineReceivedHandler(process, line, outputAction, errorAction);
         }
 
-        private void ProcessLineReceivedHandler(Process sender, string lineReceived, Action<string> outputAction, Action<string> errorAction)
+        private void ProcessLineReceivedHandler(
+            Process sender, 
+            string lineReceived, 
+            Action<string> outputAction, 
+            Action<string> errorAction)
         {
             if (!string.IsNullOrWhiteSpace(lineReceived))
             {

--- a/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
+++ b/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
@@ -90,12 +90,6 @@ namespace gMKVToolNix.MkvMerge
 
         public List<gMKVSegment> GetMKVSegments(string argMKVFile)
         {
-            // check for existence of MKVMerge
-            if (!File.Exists(_MKVMergeFilename)) 
-            { 
-                throw new Exception(string.Format("Could not find {0}!" + Environment.NewLine + "{1}", MKV_MERGE_FILENAME, _MKVMergeFilename)); 
-            }
-
             List<string> outputLines = new List<string>();
             List<string> errors = new List<string>();
 
@@ -215,12 +209,6 @@ namespace gMKVToolNix.MkvMerge
             if (_Version != null)
             {
                 return _Version;
-            }
-
-            // check for existence of mkvmerge
-            if (!File.Exists(_MKVMergeFilename))
-            {
-                throw new Exception($"Could not find {MKV_MERGE_FILENAME}!{Environment.NewLine}{_MKVMergeFilename}");
             }
 
             if (PlatformExtensions.IsOnLinux)

--- a/src/gMKVToolNix/OptionValue.cs
+++ b/src/gMKVToolNix/OptionValue.cs
@@ -1,0 +1,15 @@
+﻿namespace gMKVToolNix
+{
+    public class OptionValue<T>
+    {
+        public T Option { get; set; }
+
+        public string Parameter { get; set; }
+
+        public OptionValue(T opt, string par)
+        {
+            Option = opt;
+            Parameter = par;
+        }
+    }
+}

--- a/src/gMKVToolNix/OptionValueExtensions.cs
+++ b/src/gMKVToolNix/OptionValueExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace gMKVToolNix
+{
+    public static class OptionValueExtensions
+    {
+        public static string ConvertOptionValueListToString<T>(this List<OptionValue<T>> listOptionValue)
+        {
+            StringBuilder optionString = new StringBuilder();
+            foreach (OptionValue<T> optVal in listOptionValue)
+            {
+                optionString.Append(' ');
+                optionString.Append(ConvertEnumOptionToStringOption(optVal.Option));
+                if (!string.IsNullOrWhiteSpace(optVal.Parameter))
+                {
+                    optionString.Append(' ');
+                    optionString.Append(optVal.Parameter);
+                }
+            }
+
+            return optionString.ToString();
+        }
+
+        private static readonly Dictionary<Type, Dictionary<object, string>> _OptionsToStringMap = 
+            new Dictionary<Type, Dictionary<object, string>>();
+
+        private static void PrepareOptionsToStringMap<T>()
+        {
+            if (_OptionsToStringMap.ContainsKey(typeof(T)))
+            {
+                return; // Already prepared
+            }
+
+            var enumType = typeof(T);
+            var optionsToStringMap = Enum.GetValues(enumType)
+                .Cast<T>()
+                .ToDictionary(
+                    val => (object)val,
+                    val => $"--{val.ToString().Replace("_", "-")}"
+                );
+
+            _OptionsToStringMap[enumType] = optionsToStringMap;
+        }
+
+        private static string ConvertEnumOptionToStringOption<T>(T argEnumOption)
+        {
+            PrepareOptionsToStringMap<T>();
+
+            return _OptionsToStringMap[typeof(T)][argEnumOption];            
+        }
+    }
+}

--- a/src/gMKVToolNix/ProcessExtensions.cs
+++ b/src/gMKVToolNix/ProcessExtensions.cs
@@ -34,7 +34,7 @@ namespace gMKVToolNix
         /// <param name="processStream"></param>
         public static void ReadStreamPerCharacter(
             this Process argProcess, 
-            DataReceivedEventHandler argHandler, 
+            Action<Process, string> argLineDataHandler,
             ProcessStream processStream = ProcessStream.StandardOutput)
         {
             StreamReader reader;
@@ -66,12 +66,12 @@ namespace gMKVToolNix
                             reader.Read();
                         }
 
-                        argHandler(argProcess, GetDataReceivedEventArgs(line.ToString()));
+                        argLineDataHandler(argProcess, line.ToString());
                         line.Length = 0;
                     }
                     else if (c == '\n')
                     {
-                        argHandler(argProcess, GetDataReceivedEventArgs(line.ToString()));
+                        argLineDataHandler(argProcess, line.ToString());
                         line.Length = 0;
                     }
                     else

--- a/src/gMKVToolNix/gMKVHelper.cs
+++ b/src/gMKVToolNix/gMKVHelper.cs
@@ -237,16 +237,32 @@ namespace gMKVToolNix
         }
 
         /// <summary>
-        /// 
+        /// Creates a merged list of MKV segments using both MKVMerge and MKVInfo tools.
+        /// This is a convenience method that constructs the necessary tool instances and delegates
+        /// to the more detailed overload.
         /// </summary>
-        /// <param name="argMkvToolnixPath"></param>
-        /// <param name="argInputFile"></param>
-        /// <returns></returns>
+        /// <param name="argMkvToolnixPath">The path to the MKVToolnix installation directory</param>
+        /// <param name="argInputFile">The input MKV file to analyze</param>
+        /// <returns>A complete list of gMKVSegment objects with merged information from both tools</returns>
         public static List<gMKVSegment> GetMergedMkvSegmentList(string argMkvToolnixPath, string argInputFile)
         {
             gMKVMerge gMerge = new gMKVMerge(argMkvToolnixPath);
             gMKVInfo gInfo = new gMKVInfo(argMkvToolnixPath);
 
+            return GetMergedMkvSegmentList(gMerge, gInfo, argInputFile);
+        }
+
+        /// <summary>
+        /// Gets a merged list of MKV segments by combining information from both mkvmerge and mkvinfo.
+        /// This method retrieves segment data from mkvmerge first, then supplements missing information 
+        /// (segment info, codec private data, delays, etc.) from mkvinfo if needed.
+        /// </summary>
+        /// <param name="gMerge">The gMKVMerge instance to use for primary segment extraction</param>
+        /// <param name="gInfo">The gMKVInfo instance to use for supplementary information</param>
+        /// <param name="argInputFile">The input MKV file path to analyze</param>
+        /// <returns>A complete list of gMKVSegment objects with merged information from both tools</returns>
+        public static List<gMKVSegment> GetMergedMkvSegmentList(gMKVMerge gMerge, gMKVInfo gInfo, string argInputFile)
+        {
             List<gMKVSegment> segmentListFromMkvMerge = gMerge.GetMKVSegments(argInputFile);
 
             // Check if information was found in mkvmerge output

--- a/src/gMKVToolNix/gMKVToolNix.csproj
+++ b/src/gMKVToolNix/gMKVToolNix.csproj
@@ -69,6 +69,8 @@
     <Compile Include="MkvExtract\gMKVExtractExtensions.cs" />
     <Compile Include="MkvExtract\TrackParameter.cs" />
     <Compile Include="MkvMerge\CodecPrivateDataExtensions.cs" />
+    <Compile Include="OptionValue.cs" />
+    <Compile Include="OptionValueExtensions.cs" />
     <Compile Include="PlatformExtensions.cs" />
     <Compile Include="ProcessExtensions.cs" />
     <Compile Include="ProcessStream.cs" />

--- a/src/gMKVToolNix/gMKVVersionParser.cs
+++ b/src/gMKVToolNix/gMKVVersionParser.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace gMKVToolNix
@@ -16,9 +17,9 @@ namespace gMKVToolNix
             FilePrivatePart = 0
         };
 
-        public static gMKVVersion ParseVersionOutput(string mkvtoolnixOutput)
+        public static gMKVVersion ParseVersionOutput(List<string> mkvtoolnixOutputLines)
         {
-            if (string.IsNullOrWhiteSpace(mkvtoolnixOutput))
+            if (mkvtoolnixOutputLines == null || !mkvtoolnixOutputLines.Any())
             {
                 return _defaultEmptyVersion;
             }
@@ -27,9 +28,13 @@ namespace gMKVToolNix
             string fileMinorVersion = null;
             string filePrivateVersion = null;
 
-            string[] outputLines = mkvtoolnixOutput.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (string outputLine in outputLines)
+            foreach (string outputLine in mkvtoolnixOutputLines)
             {
+                if (string.IsNullOrWhiteSpace(outputLine))
+                {
+                    continue; // Skip empty or whitespace lines
+                }
+
                 Match match = _versionRegEx.Match(outputLine);
                 if (match.Success)
                 {

--- a/tests/gMKVToolnix.Unit.Tests/gMkvParser.Tests.cs
+++ b/tests/gMKVToolnix.Unit.Tests/gMkvParser.Tests.cs
@@ -1,4 +1,5 @@
-﻿using gMKVToolNix;
+﻿using System.Collections.Generic;
+using gMKVToolNix;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace gMKVToolnix.Unit.Tests
@@ -6,7 +7,7 @@ namespace gMKVToolnix.Unit.Tests
     [TestClass]
     public sealed class gMkvParser_Tests
     {
-        private void ActAndAssertVersionParsed(string output, int major, int minor, int priv)
+        private void ActAndAssertVersionParsed(List<string> output, int major, int minor, int priv)
         {
             gMKVVersion gMKVVersion = gMKVVersionParser.ParseVersionOutput(output);
 
@@ -18,28 +19,28 @@ namespace gMKVToolnix.Unit.Tests
         [TestMethod]
         public void VersionOutput_ShouldBe_Parsed_Successfully()
         {
-            ActAndAssertVersionParsed("mkvmerge v64.0.0 ('The Last Goodbye') 64-bit", 64, 0, 0);
-            ActAndAssertVersionParsed("mkvmerge v12.5.7 ('Some Name') 32-bit", 12, 5, 7);
-            ActAndAssertVersionParsed("mkvmerge v1.2.3 ('Test') 64-bit", 1, 2, 3);
-            ActAndAssertVersionParsed("mkvmerge v86.0 ('Winter') 64-bit", 86, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvmerge v64.0.0 ('The Last Goodbye') 64-bit" }, 64, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvmerge v12.5.7 ('Some Name') 32-bit" }, 12, 5, 7);
+            ActAndAssertVersionParsed(new List<string>() { "mkvmerge v1.2.3 ('Test') 64-bit" }, 1, 2, 3);
+            ActAndAssertVersionParsed(new List<string>() { "mkvmerge v86.0 ('Winter') 64-bit" }, 86, 0, 0);
 
-            ActAndAssertVersionParsed("mkvinfo v64.0.0 ('The Last Goodbye') 64-bit", 64, 0, 0);
-            ActAndAssertVersionParsed("mkvinfo v12.5.7 ('Some Name') 32-bit", 12, 5, 7);
-            ActAndAssertVersionParsed("mkvinfo v1.2.3 ('Test') 64-bit", 1, 2, 3);
-            ActAndAssertVersionParsed("mkvinfo v86.0 ('Winter') 64-bit", 86, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvinfo v64.0.0 ('The Last Goodbye') 64-bit" }, 64, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvinfo v12.5.7 ('Some Name') 32-bit" }, 12, 5, 7);
+            ActAndAssertVersionParsed(new List<string>() { "mkvinfo v1.2.3 ('Test') 64-bit" }, 1, 2, 3);
+            ActAndAssertVersionParsed(new List<string>() { "mkvinfo v86.0 ('Winter') 64-bit" }, 86, 0, 0);
 
-            ActAndAssertVersionParsed("mkvextract v64.0.0 ('The Last Goodbye') 64-bit", 64, 0, 0);
-            ActAndAssertVersionParsed("mkvextract v12.5.7 ('Some Name') 32-bit", 12, 5, 7);
-            ActAndAssertVersionParsed("mkvextract v1.2.3 ('Test') 64-bit", 1, 2, 3);
-            ActAndAssertVersionParsed("mkvextract v86.0 ('Winter') 64-bit", 86, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvextract v64.0.0 ('The Last Goodbye') 64-bit" }, 64, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "mkvextract v12.5.7 ('Some Name') 32-bit" }, 12, 5, 7);
+            ActAndAssertVersionParsed(new List<string>() { "mkvextract v1.2.3 ('Test') 64-bit" }, 1, 2, 3);
+            ActAndAssertVersionParsed(new List<string>() { "mkvextract v86.0 ('Winter') 64-bit" }, 86, 0, 0);
         }
 
         [TestMethod]
         public void VersionNullOrEmptyOutput_ShouldBe_NotParsed_ReturnDefaultVersion()
         {
-            ActAndAssertVersionParsed(null, 0, 0, 0);
-            ActAndAssertVersionParsed("", 0, 0, 0);
-            ActAndAssertVersionParsed(" ", 0, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { null }, 0, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { "" }, 0, 0, 0);
+            ActAndAssertVersionParsed(new List<string>() { " " }, 0, 0, 0);
         }
     }
 }


### PR DESCRIPTION
- Huge refactor of parsing state, practically making parsing stateless
- Refactored the process output handling, by using List<string> instead of StringBuilder to avoid splitting into individual line strings afterwards
- Removed file existence checks for batch requests to minimize the IO operations
- Various code optimizations in string operations
- Various code formatting improvements

