### PR TITLE
Add support for the Forced track property

### DIFF
--- a/src/gMKVExtractGUI/Forms/frmOptions.cs
+++ b/src/gMKVExtractGUI/Forms/frmOptions.cs
@@ -181,6 +181,7 @@ namespace gMKVToolNix.Forms
             _VideoTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Codec Private", gMKVExtractFilenamePatterns.TrackCodecPrivate, txtVideoTracksFilename));
             _VideoTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Delay", gMKVExtractFilenamePatterns.TrackDelay, txtVideoTracksFilename));
             _VideoTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Effective Delay", gMKVExtractFilenamePatterns.TrackEffectiveDelay, txtVideoTracksFilename));
+            _VideoTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Forced", gMKVExtractFilenamePatterns.TrackForced, txtVideoTracksFilename));
             _VideoTrackContextMenu.Items.Add("-");
 
             var audTrackNumber = new ToolStripMenuItem("Track Number...", null);
@@ -208,6 +209,7 @@ namespace gMKVToolNix.Forms
             _AudioTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Codec Private", gMKVExtractFilenamePatterns.TrackCodecPrivate, txtAudioTracksFilename));
             _AudioTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Delay", gMKVExtractFilenamePatterns.TrackDelay, txtAudioTracksFilename));
             _AudioTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Effective Delay", gMKVExtractFilenamePatterns.TrackEffectiveDelay, txtAudioTracksFilename));
+            _AudioTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Forced", gMKVExtractFilenamePatterns.TrackForced, txtAudioTracksFilename));
             _AudioTrackContextMenu.Items.Add("-");
 
             var subTrackNumber = new ToolStripMenuItem("Track Number...", null);
@@ -235,6 +237,7 @@ namespace gMKVToolNix.Forms
             _SubtitleTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Codec Private", gMKVExtractFilenamePatterns.TrackCodecPrivate, txtSubtitleTracksFilename));
             _SubtitleTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Delay", gMKVExtractFilenamePatterns.TrackDelay, txtSubtitleTracksFilename));
             _SubtitleTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Effective Delay", gMKVExtractFilenamePatterns.TrackEffectiveDelay, txtSubtitleTracksFilename));
+            _SubtitleTrackContextMenu.Items.Add(GetToolstripMenuItem("Track Forced", gMKVExtractFilenamePatterns.TrackForced, txtSubtitleTracksFilename));
             // ============================================================================================================================
 
             // Video Track placeholders

--- a/src/gMKVToolNix/MkvExtract/gMKVExtractExtensions.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtractExtensions.cs
@@ -44,6 +44,7 @@ namespace gMKVToolNix.MkvExtract
                 finalFilename = finalFilename.Replace(gMKVExtractFilenamePatterns.TrackCodecPrivate, track.CodecPrivate);
                 finalFilename = finalFilename.Replace(gMKVExtractFilenamePatterns.TrackDelay, track.Delay.ToString());
                 finalFilename = finalFilename.Replace(gMKVExtractFilenamePatterns.TrackEffectiveDelay, track.EffectiveDelay.ToString());
+                finalFilename = finalFilename.Replace(gMKVExtractFilenamePatterns.TrackForced, track.Forced ? "FORCED" : "");
 
                 // Video Track placeholders
                 if (track.TrackType == MkvTrackType.video)

--- a/src/gMKVToolNix/MkvExtract/gMKVExtractFilenamePatterns.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtractFilenamePatterns.cs
@@ -25,6 +25,7 @@ namespace gMKVToolNix.MkvExtract
         public static readonly string TrackCodecPrivate = "{CodecPrivate}";
         public static readonly string TrackDelay = "{Delay}";
         public static readonly string TrackEffectiveDelay = "{EffectiveDelay}";
+        public static readonly string TrackForced = "{TrackForced}";
 
         // Video Track placeholders
         public static readonly string VideoPixelWidth = "{PixelWidth}";

--- a/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
+++ b/src/gMKVToolNix/MkvMerge/gMKVMerge.cs
@@ -685,6 +685,10 @@ namespace gMKVToolNix.MkvMerge
                                             {
                                                 tmpTrack.TrackName = propertyFinal.ToObject<string>();
                                             }
+                                            else if (propertyFinalName == "forced_track")
+                                            {
+                                                tmpTrack.Forced = propertyFinal.ToObject<bool>();
+                                            }
                                             else if (propertyFinalName == "language")
                                             {
                                                 tmpTrack.Language = propertyFinal.ToObject<string>();
@@ -911,6 +915,12 @@ namespace gMKVToolNix.MkvMerge
                     if (outputLine.Contains("track_name:"))
                     {
                         tmpTrack.TrackName = ExtractProperty(outputLine, "track_name");
+                    }
+                    
+                    if (outputLine.Contains("forced_track:"))
+                    {
+                        string forcedProperty = ExtractProperty(outputLine, "forced_track");
+                        tmpTrack.Forced = forcedProperty.Trim().Equals("1");
                     }
 
                     if (outputLine.Contains("codec_private_data:"))

--- a/src/gMKVToolNix/Segments/gMKVTrack.cs
+++ b/src/gMKVToolNix/Segments/gMKVTrack.cs
@@ -17,6 +17,8 @@ namespace gMKVToolNix.Segments
         public string CodecPrivate { get; set; } = "";
 
         public string CodecPrivateData { get; set; } = "";
+        
+        public bool Forced { get; set; } = false;
 
         public string Language { get; set; } = "";
 
@@ -35,7 +37,6 @@ namespace gMKVToolNix.Segments
         /// </summary>
         public long MinimumTimestamp { get; set; } = long.MinValue;
 
-
         public int VideoPixelWidth { get; set; }
         public int VideoPixelHeight { get; set; }
 
@@ -46,14 +47,32 @@ namespace gMKVToolNix.Segments
         {
             StringBuilder outputBuilder = new StringBuilder();
 
-            outputBuilder.Append($"Track {TrackNumber} [TID {TrackID}][{TrackType}][{CodecID}][{TrackName}][{Language}]");
+            outputBuilder.Append($"Track {TrackNumber} [TID {TrackID}][{TrackType}][{CodecID}]");
+
+            if (!string.IsNullOrWhiteSpace(TrackName))
+            {
+                outputBuilder.Append($"[{TrackName}]");
+            }
+
+            if (!string.IsNullOrWhiteSpace(Language))
+            {
+                outputBuilder.Append($"[{Language}]");
+            }
 
             if (!string.IsNullOrWhiteSpace(LanguageIetf))
             {
                 outputBuilder.Append($"[{LanguageIetf}]");
             }
 
-            outputBuilder.Append($"[{ExtraInfo}]");
+            if (Forced)
+            {
+                outputBuilder.Append("[FORCED]");
+            }
+
+            if (!string.IsNullOrWhiteSpace(ExtraInfo))
+            {
+                outputBuilder.Append($"[{ExtraInfo}]");
+            }            
 
             if (!string.IsNullOrWhiteSpace(CodecPrivate))
             {
@@ -85,6 +104,7 @@ namespace gMKVToolNix.Segments
                 && Delay == other.Delay
                 && EffectiveDelay == other.EffectiveDelay
                 && ExtraInfo.Equals(other.ExtraInfo, StringComparison.OrdinalIgnoreCase)
+                && Forced.Equals(other.Forced)
                 && Language.Equals(other.Language, StringComparison.OrdinalIgnoreCase)
                 && LanguageIetf.Equals(other.LanguageIetf, StringComparison.OrdinalIgnoreCase)
                 && MinimumTimestamp == other.MinimumTimestamp
@@ -112,6 +132,7 @@ namespace gMKVToolNix.Segments
                 hash = hash * 23 + Delay.GetHashCode();
                 hash = hash * 23 + EffectiveDelay.GetHashCode();
                 hash = hash * 23 + ExtraInfo.GetHashCode();
+                hash = hash * 23 + Forced.GetHashCode();
                 hash = hash * 23 + Language.GetHashCode();
                 hash = hash * 23 + LanguageIetf.GetHashCode();
                 hash = hash * 23 + MinimumTimestamp.GetHashCode();


### PR DESCRIPTION
#### PR Classification
New feature to support forced track selection and representation in the application.

#### PR Summary
This pull request adds functionality for handling forced tracks in the video, audio, and subtitle contexts, including UI updates and backend logic for filename generation and track properties.
- `frmOptions.cs`: Added "Track Forced" menu item for video, audio, and subtitle tracks.
- `gMKExtractExtensions.cs`: Updated filename generation to include forced track information.
- `gMKExtractFilenamePatterns.cs`: Introduced new string pattern `TrackForced` for filename templates.
- `gMKVMerge.cs`: Enhanced parsing logic to handle the "forced_track" property.
- `gMKTrack.cs`: Added `Forced` property and updated `ToString` method to reflect forced status.
