### PR TITLE
Fix: Ensure AutoDetectMkvToolnixPath runs when MKVToolnix Path is empty. For #28

### DIFF
--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -196,10 +196,9 @@ namespace gMKVToolNix.Forms
                     try
                     {
                         // First check the ini file
-                        gMKVLogger.Log($"Checking in ini path for mkvmerge... ({_Settings.MkvToolnixPath})");
-
-                        if (File.Exists(Path.Combine(_Settings.MkvToolnixPath, gMKVHelper.MKV_MERGE_GUI_FILENAME))
-                            || File.Exists(Path.Combine(_Settings.MkvToolnixPath, gMKVHelper.MKV_MERGE_NEW_GUI_FILENAME)))
+                        if (!string.IsNullOrWhiteSpace(_Settings.MkvToolnixPath)
+                            && (File.Exists(Path.Combine(_Settings.MkvToolnixPath, gMKVHelper.MKV_MERGE_GUI_FILENAME))
+                            || File.Exists(Path.Combine(_Settings.MkvToolnixPath, gMKVHelper.MKV_MERGE_NEW_GUI_FILENAME))))
                         {
                             // We set the flag to bypass the checks
                             // since the path already exists in the settings


### PR DESCRIPTION
### Problem

When gMKVExtractGUI is started **directly**, the detection of `mmg/mkvmerge.exe` is skipped if `MKVToolnix Path` in the `.ini` file is empty.  

- If `_Settings.MkvToolnixPath` is empty, the existence check falls back to the **current working directory**.  
- When the app is **opened by double-click**, the working directory happens to contain `mkvmerge.exe`, so it is detected.  
- But when the app is **opened by dragging an MKV file**, the working directory is different, so `mkvmerge.exe` is not found.  
- As a result, `AutoDetectMkvToolnixPath` is skipped entirely, leading to failure to detect MKVToolnix.

---

### Root Cause

- `MKVToolnix Path` being empty in the `.ini` file.  
- The existence check incorrectly succeeds or fails depending on the working directory.  
- This caused inconsistent behavior:  
  - **Direct open** → succeeds (due to working dir containing mkvmerge).  
  - **Drag-drop open** → fails (different working dir).  

---

### Solution

Before performing the detection checks, explicitly verify that `_Settings.MkvToolnixPath` is **not empty or whitespace**.  
- If empty → force `AutoDetectMkvToolnixPath` to run.  
- Otherwise → continue with the normal path checks.  

This ensures consistent detection regardless of how the program is started.
