### PR TITLE
feat: Add option to disable BOM for text files (v96.0+) #31

### DIFF
--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -1159,18 +1159,21 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.NoCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Cue_Sheet:
                             parameterList.MKVFile = infoSegment.Path;
                             parameterList.OutputDirectory = outputDirectory;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Tags:
                             parameterList.MKVFile = infoSegment.Path;
                             parameterList.OutputDirectory = outputDirectory;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Timecodes:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1181,6 +1184,7 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.NoCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Tracks_And_Timecodes:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1191,6 +1195,7 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.NoCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Cues:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1201,6 +1206,7 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.OnlyCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Tracks_And_Cues:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1211,6 +1217,7 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.WithCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                         case FormMkvExtractionMode.Tracks_And_Cues_And_Timecodes:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1221,6 +1228,7 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.CueExtractionMode = CuesExtractionMode.WithCues;
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
+                            parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
                             break;
                     }
                     jobs.Add(new gMKVJob(extractionMode, txtMKVToolnixPath.Text, parameterList));

--- a/src/gMKVExtractGUI/Forms/frmOptions.Designer.cs
+++ b/src/gMKVExtractGUI/Forms/frmOptions.Designer.cs
@@ -37,10 +37,6 @@
             this.btnDefaultChapterPlaceholder = new System.Windows.Forms.Button();
             this.btnAddChapterPlaceholder = new System.Windows.Forms.Button();
             this.txtChaptersFilename = new gMKVToolNix.gTextBox();
-            this.grpActions = new gMKVToolNix.gGroupBox();
-            this.btnDefaults = new System.Windows.Forms.Button();
-            this.btnOK = new System.Windows.Forms.Button();
-            this.btnCancel = new System.Windows.Forms.Button();
             this.grpVideoTracks = new gMKVToolNix.gGroupBox();
             this.btnDefaultVideoTrackPlaceholder = new System.Windows.Forms.Button();
             this.btnAddVideoTrackPlaceholder = new System.Windows.Forms.Button();
@@ -60,15 +56,22 @@
             this.grpInfo = new gMKVToolNix.gGroupBox();
             this.txtInfo = new gMKVToolNix.gRichTextBox();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.grpActions = new gMKVToolNix.gGroupBox();
+            this.btnDefaults = new System.Windows.Forms.Button();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.grpAdvanced = new gMKVToolNix.gGroupBox();
+            this.chkTextFilesWithoutBom = new System.Windows.Forms.CheckBox();
             this.tlpMain.SuspendLayout();
             this.grpTags.SuspendLayout();
             this.grpChapters.SuspendLayout();
-            this.grpActions.SuspendLayout();
             this.grpVideoTracks.SuspendLayout();
             this.grpAudioTracks.SuspendLayout();
             this.grpSubtitleTracks.SuspendLayout();
             this.grpAttachments.SuspendLayout();
             this.grpInfo.SuspendLayout();
+            this.grpActions.SuspendLayout();
+            this.grpAdvanced.SuspendLayout();
             this.SuspendLayout();
             // 
             // tlpMain
@@ -77,17 +80,18 @@
             this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpMain.Controls.Add(this.grpTags, 0, 6);
             this.tlpMain.Controls.Add(this.grpChapters, 0, 4);
-            this.tlpMain.Controls.Add(this.grpActions, 0, 7);
             this.tlpMain.Controls.Add(this.grpVideoTracks, 0, 1);
             this.tlpMain.Controls.Add(this.grpAudioTracks, 0, 2);
             this.tlpMain.Controls.Add(this.grpSubtitleTracks, 0, 3);
             this.tlpMain.Controls.Add(this.grpAttachments, 0, 5);
             this.tlpMain.Controls.Add(this.grpInfo, 0, 0);
-            this.tlpMain.Controls.Add(this.statusStrip1, 0, 8);
+            this.tlpMain.Controls.Add(this.statusStrip1, 0, 9);
+            this.tlpMain.Controls.Add(this.grpActions, 0, 8);
+            this.tlpMain.Controls.Add(this.grpAdvanced, 0, 7);
             this.tlpMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpMain.Location = new System.Drawing.Point(0, 0);
             this.tlpMain.Name = "tlpMain";
-            this.tlpMain.RowCount = 9;
+            this.tlpMain.RowCount = 10;
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
@@ -96,8 +100,9 @@
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tlpMain.Size = new System.Drawing.Size(654, 561);
+            this.tlpMain.Size = new System.Drawing.Size(654, 621);
             this.tlpMain.TabIndex = 0;
             // 
             // grpTags
@@ -189,51 +194,6 @@
             this.txtChaptersFilename.Name = "txtChaptersFilename";
             this.txtChaptersFilename.Size = new System.Drawing.Size(462, 23);
             this.txtChaptersFilename.TabIndex = 1;
-            // 
-            // grpActions
-            // 
-            this.grpActions.Controls.Add(this.btnDefaults);
-            this.grpActions.Controls.Add(this.btnOK);
-            this.grpActions.Controls.Add(this.btnCancel);
-            this.grpActions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpActions.Location = new System.Drawing.Point(3, 484);
-            this.grpActions.Name = "grpActions";
-            this.grpActions.Size = new System.Drawing.Size(648, 54);
-            this.grpActions.TabIndex = 0;
-            this.grpActions.TabStop = false;
-            // 
-            // btnDefaults
-            // 
-            this.btnDefaults.Location = new System.Drawing.Point(9, 17);
-            this.btnDefaults.Name = "btnDefaults";
-            this.btnDefaults.Size = new System.Drawing.Size(83, 30);
-            this.btnDefaults.TabIndex = 6;
-            this.btnDefaults.Text = "Defaults";
-            this.btnDefaults.UseVisualStyleBackColor = true;
-            this.btnDefaults.Click += new System.EventHandler(this.btnDefaults_Click);
-            // 
-            // btnOK
-            // 
-            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.Location = new System.Drawing.Point(476, 17);
-            this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(80, 30);
-            this.btnOK.TabIndex = 1;
-            this.btnOK.Text = "OK";
-            this.btnOK.UseVisualStyleBackColor = true;
-            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-            // 
-            // btnCancel
-            // 
-            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(562, 17);
-            this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(80, 30);
-            this.btnCancel.TabIndex = 0;
-            this.btnCancel.Text = "Cancel";
-            this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // grpVideoTracks
             // 
@@ -442,16 +402,82 @@
             // statusStrip1
             // 
             this.statusStrip1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.statusStrip1.Location = new System.Drawing.Point(0, 541);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 601);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(654, 20);
             this.statusStrip1.TabIndex = 6;
             this.statusStrip1.Text = "statusStrip1";
             // 
+            // grpActions
+            // 
+            this.grpActions.Controls.Add(this.btnDefaults);
+            this.grpActions.Controls.Add(this.btnOK);
+            this.grpActions.Controls.Add(this.btnCancel);
+            this.grpActions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpActions.Location = new System.Drawing.Point(3, 544);
+            this.grpActions.Name = "grpActions";
+            this.grpActions.Size = new System.Drawing.Size(648, 54);
+            this.grpActions.TabIndex = 0;
+            this.grpActions.TabStop = false;
+            // 
+            // btnDefaults
+            // 
+            this.btnDefaults.Location = new System.Drawing.Point(9, 17);
+            this.btnDefaults.Name = "btnDefaults";
+            this.btnDefaults.Size = new System.Drawing.Size(83, 30);
+            this.btnDefaults.TabIndex = 6;
+            this.btnDefaults.Text = "Defaults";
+            this.btnDefaults.UseVisualStyleBackColor = true;
+            this.btnDefaults.Click += new System.EventHandler(this.btnDefaults_Click);
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOK.Location = new System.Drawing.Point(476, 17);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(80, 30);
+            this.btnOK.TabIndex = 1;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(562, 17);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(80, 30);
+            this.btnCancel.TabIndex = 0;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // grpAdvanced
+            // 
+            this.grpAdvanced.Controls.Add(this.chkTextFilesWithoutBom);
+            this.grpAdvanced.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpAdvanced.Location = new System.Drawing.Point(3, 484);
+            this.grpAdvanced.Name = "grpAdvanced";
+            this.grpAdvanced.Size = new System.Drawing.Size(648, 54);
+            this.grpAdvanced.TabIndex = 8;
+            this.grpAdvanced.TabStop = false;
+            this.grpAdvanced.Text = "Advanced Options";
+            // 
+            // chkTextFilesWithoutBom
+            // 
+            this.chkTextFilesWithoutBom.AutoSize = true;
+            this.chkTextFilesWithoutBom.Location = new System.Drawing.Point(9, 22);
+            this.chkTextFilesWithoutBom.Name = "chkTextFilesWithoutBom";
+            this.chkTextFilesWithoutBom.Size = new System.Drawing.Size(200, 19);
+            this.chkTextFilesWithoutBom.TabIndex = 0;
+            this.chkTextFilesWithoutBom.Text = "Disable BOM to text files (v96.0+)";
+            this.chkTextFilesWithoutBom.UseVisualStyleBackColor = true;
+            // 
             // frmOptions
             // 
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(654, 561);
+            this.ClientSize = new System.Drawing.Size(654, 621);
             this.Controls.Add(this.tlpMain);
             this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(161)));
             this.MinimumSize = new System.Drawing.Size(400, 400);
@@ -465,7 +491,6 @@
             this.grpTags.PerformLayout();
             this.grpChapters.ResumeLayout(false);
             this.grpChapters.PerformLayout();
-            this.grpActions.ResumeLayout(false);
             this.grpVideoTracks.ResumeLayout(false);
             this.grpVideoTracks.PerformLayout();
             this.grpAudioTracks.ResumeLayout(false);
@@ -475,6 +500,9 @@
             this.grpAttachments.ResumeLayout(false);
             this.grpAttachments.PerformLayout();
             this.grpInfo.ResumeLayout(false);
+            this.grpActions.ResumeLayout(false);
+            this.grpAdvanced.ResumeLayout(false);
+            this.grpAdvanced.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -513,5 +541,7 @@
         private System.Windows.Forms.Button btnDefaultTagsPlaceholder;
         private System.Windows.Forms.Button btnAddTagsPlaceholder;
         private gTextBox txtTagsFilename;
+        private gGroupBox grpAdvanced;
+        private System.Windows.Forms.CheckBox chkTextFilesWithoutBom;
     }
 }

--- a/src/gMKVExtractGUI/Forms/frmOptions.cs
+++ b/src/gMKVExtractGUI/Forms/frmOptions.cs
@@ -89,6 +89,7 @@ Pressing the ""Default"" button you will reset the output filename format to its
             txtChaptersFilename.Text = _Settings.ChapterFilenamePattern;
             txtAttachmentsFilename.Text = _Settings.AttachmentFilenamePattern;
             txtTagsFilename.Text = _Settings.TagsFilenamePattern;
+            chkTextFilesWithoutBom.Checked = _Settings.DisableBomForTextFiles;
         }
 
         private void UpdateSettings()
@@ -99,6 +100,7 @@ Pressing the ""Default"" button you will reset the output filename format to its
             _Settings.ChapterFilenamePattern = txtChaptersFilename.Text;
             _Settings.AttachmentFilenamePattern = txtAttachmentsFilename.Text;
             _Settings.TagsFilenamePattern = txtTagsFilename.Text;
+            _Settings.DisableBomForTextFiles = chkTextFilesWithoutBom.Checked;
         }
 
         private ToolStripMenuItem GetToolstripMenuItem(string description, string placeholder, TextBox txtBox)

--- a/src/gMKVExtractGUI/gSettings.cs
+++ b/src/gMKVExtractGUI/gSettings.cs
@@ -131,6 +131,13 @@ namespace gMKVToolNix
             set { _DarkMode = value; }
         }
 
+        private bool _DisableBomForTextFiles = false;
+        public bool DisableBomForTextFiles
+        {
+            get { return _DisableBomForTextFiles; }
+            set { _DisableBomForTextFiles = value; }
+        }
+
         private string _VideoTrackFilenamePattern = "{FilenameNoExt}_track{TrackNumber}_[{Language}]";
         [DefaultValue("{FilenameNoExt}_track{TrackNumber}_[{Language}]")]
         public string VideoTrackFilenamePattern
@@ -567,6 +574,19 @@ namespace gMKVToolNix
                                 _DarkMode = false; // Default to false on error
                             }
                         }
+                        else if (line.StartsWith("DisableBomForTextFiles:"))
+                        {
+                            try
+                            {
+                                _DisableBomForTextFiles = bool.Parse(line.Substring(line.IndexOf(":") + 1));
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine(ex);
+                                gMKVLogger.Log(string.Format("Error reading DisableBomForTextFiles! {0}", ex.Message));
+                                _DisableBomForTextFiles = false; // Default to false on error
+                            }
+                        }
                     }
                 }
                 gMKVLogger.Log("Finished loading settings!");
@@ -595,6 +615,7 @@ namespace gMKVToolNix
                 sw.WriteLine(string.Format("Overwrite Existing Files:{0}", _OverwriteExistingFiles));
                 sw.WriteLine(string.Format("Disable Tooltips:{0}", _DisableTooltips));
                 sw.WriteLine(string.Format("DarkMode:{0}", _DarkMode));
+                sw.WriteLine(string.Format("DisableBomForTextFiles:{0}", _DisableBomForTextFiles));
 
                 sw.WriteLine(string.Format("VideoTrackFilenamePattern:{0}", _VideoTrackFilenamePattern));
                 sw.WriteLine(string.Format("AudioTrackFilenamePattern:{0}", _AudioTrackFilenamePattern));

--- a/src/gMKVToolNix/MkvExtract/TrackParameter.cs
+++ b/src/gMKVToolNix/MkvExtract/TrackParameter.cs
@@ -6,6 +6,7 @@
         public string Options { get; set; } = "";
         public string TrackOutput { get; set; } = "";
         public bool WriteOutputToFile { get; set; } = false;
+        public bool DisableBomForTextFiles { get; set; } = false;
         public string OutputFilename { get; set; } = "";
 
         public TrackParameter(
@@ -13,12 +14,14 @@
             string argOptions,
             string argTrackOutput,
             bool argWriteOutputToFile,
+            bool argDisableBomForTextFiles,
             string argOutputFilename)
         {
             ExtractMode = argExtractMode;
             Options = argOptions;
             TrackOutput = argTrackOutput;
             WriteOutputToFile = argWriteOutputToFile;
+            DisableBomForTextFiles = argDisableBomForTextFiles;
             OutputFilename = argOutputFilename;
         }
 

--- a/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
@@ -75,6 +75,7 @@ namespace gMKVToolNix.MkvExtract
                     parameters.TimecodesExtractionMode,
                     parameters.CueExtractionMode,
                     parameters.FilenamePatterns,
+                    parameters.DisableBomForTextFiles,
                     parameters.OverwriteExistingFile
                 );
             }
@@ -92,6 +93,7 @@ namespace gMKVToolNix.MkvExtract
             , TimecodesExtractionMode argTimecodesExtractionMode
             , CuesExtractionMode argCueExtractionMode
             , gMKVExtractFilenamePatterns argFilenamePatterns
+            , bool argDisableBomForTextFiles
             , bool argOverwriteExistingFile
         )
         {
@@ -120,6 +122,7 @@ namespace gMKVToolNix.MkvExtract
                             argTimecodesExtractionMode, 
                             argCueExtractionMode, 
                             argFilenamePatterns,
+                            argDisableBomForTextFiles,
                             argOverwriteExistingFile,
                             _Version));
                 }
@@ -259,6 +262,7 @@ namespace gMKVToolNix.MkvExtract
                     TimecodesExtractionMode.OnlyTimecodes,
                     CuesExtractionMode.NoCues,
                     parameters.FilenamePatterns,
+                    parameters.DisableBomForTextFiles,
                     parameters.OverwriteExistingFile
                 );
             }
@@ -282,6 +286,7 @@ namespace gMKVToolNix.MkvExtract
                     TimecodesExtractionMode.NoTimecodes,
                     CuesExtractionMode.OnlyCues,
                     parameters.FilenamePatterns,
+                    parameters.DisableBomForTextFiles,
                     parameters.OverwriteExistingFile
                 );
             }
@@ -301,6 +306,7 @@ namespace gMKVToolNix.MkvExtract
                     parameters.MKVFile,
                     parameters.OutputDirectory,
                     parameters.FilenamePatterns,
+                    parameters.DisableBomForTextFiles,
                     parameters.OverwriteExistingFile
                 );
             }
@@ -314,6 +320,7 @@ namespace gMKVToolNix.MkvExtract
             string argMKVFile, 
             string argOutputDirectory, 
             gMKVExtractFilenamePatterns argFilenamePatterns,
+            bool argDisableBomForTextFiles,
             bool argOverwriteExistingFile)
         {
             Abort = false;
@@ -346,6 +353,7 @@ namespace gMKVToolNix.MkvExtract
                         , ""
                         , _Version.FileMajorPart >= 17 ? cueFile : ""
                         , _Version.FileMajorPart < 17
+                        , argDisableBomForTextFiles
                         , _Version.FileMajorPart >= 17 ? "" : cueFile
                     )
                     , errors
@@ -382,6 +390,7 @@ namespace gMKVToolNix.MkvExtract
                     parameters.MKVFile,
                     parameters.OutputDirectory,
                     parameters.FilenamePatterns,
+                    parameters.DisableBomForTextFiles,
                     parameters.OverwriteExistingFile
                 );
             }
@@ -395,6 +404,7 @@ namespace gMKVToolNix.MkvExtract
             string argMKVFile, 
             string argOutputDirectory, 
             gMKVExtractFilenamePatterns argFilenamePatterns,
+            bool argDisableBomForTextFiles,
             bool argOverwriteExistingFile)
         {
             Abort = false;
@@ -427,6 +437,7 @@ namespace gMKVToolNix.MkvExtract
                         , ""
                         , _Version.FileMajorPart >= 17 ? tagsFile : ""
                         , _Version.FileMajorPart < 17
+                        , argDisableBomForTextFiles
                         , _Version.FileMajorPart >= 17 ? "" : tagsFile
                     )
                     , errors
@@ -471,6 +482,7 @@ namespace gMKVToolNix.MkvExtract
             , TimecodesExtractionMode argTimecodesExtractionMode
             , CuesExtractionMode argCueExtractionMode
             , gMKVExtractFilenamePatterns argFilenamePatterns
+            , bool argDisableBomForTextFiles
             , bool argOverwriteExistingFile
             , gMKVVersion version)
         {
@@ -497,6 +509,7 @@ namespace gMKVToolNix.MkvExtract
                                 MkvExtractModes.timestamps_v2)
                         ),
                         false,
+                        argDisableBomForTextFiles,
                         ""
                     ));
                 }
@@ -517,6 +530,7 @@ namespace gMKVToolNix.MkvExtract
                                 MkvExtractModes.cues)
                         ),
                         false,
+                        argDisableBomForTextFiles,
                         ""
                     ));
                 }
@@ -551,6 +565,7 @@ namespace gMKVToolNix.MkvExtract
                                 MkvExtractModes.tracks)
                         ),
                         false,
+                        argDisableBomForTextFiles,
                         ""
                     ));
                 }
@@ -587,6 +602,7 @@ namespace gMKVToolNix.MkvExtract
                                 MkvExtractModes.attachments)
                         ),
                         false,
+                        argDisableBomForTextFiles,
                         ""
                     ));
                 }
@@ -631,6 +647,7 @@ namespace gMKVToolNix.MkvExtract
                         options,
                         version.FileMajorPart >= 17 ? chapterFile : "",
                         version.FileMajorPart < 17,
+                        argDisableBomForTextFiles,
                         version.FileMajorPart >= 17 ? "" : chapterFile
                     ));
                 }
@@ -709,6 +726,16 @@ namespace gMKVToolNix.MkvExtract
                         Environment.SetEnvironmentVariable("LC_MESSAGES", "en_US.UTF-8", EnvironmentVariableTarget.Process);
 
                         gMKVLogger.Log("Setting Environment Variables: LC_ALL=LANG=LC_MESSAGES=\"en_US.UTF-8\"");
+                    }
+                }
+
+                // Since MKVToolNix v96.0, we can disable writing the BOM for output text files
+                // https://codeberg.org/mbunkus/mkvtoolnix/issues/6166
+                if (_Version.FileMajorPart >= 96)
+                {
+                    if (argParameter.DisableBomForTextFiles)
+                    {
+                        parameters = $"{parameters} --no-bom";
                     }
                 }
 

--- a/src/gMKVToolNix/MkvExtract/gMKVExtractSegmentsParameters.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtractSegmentsParameters.cs
@@ -14,6 +14,7 @@ namespace gMKVToolNix.MkvExtract
         public TimecodesExtractionMode TimecodesExtractionMode { get; set; }
         public CuesExtractionMode CueExtractionMode { get; set; }
         public gMKVExtractFilenamePatterns FilenamePatterns { get; set; }
+        public bool DisableBomForTextFiles { get; set; } = false;
         public bool OverwriteExistingFile { get; set; } = false;
 
         public override bool Equals(object oth)
@@ -34,6 +35,7 @@ namespace gMKVToolNix.MkvExtract
                 && TimecodesExtractionMode == other.TimecodesExtractionMode
                 && CueExtractionMode == other.CueExtractionMode
                 && FilenamePatterns.Equals(other.FilenamePatterns)
+                && DisableBomForTextFiles.Equals(other.DisableBomForTextFiles)
                 && OverwriteExistingFile.Equals(other.OverwriteExistingFile)
             ;
         }
@@ -50,6 +52,7 @@ namespace gMKVToolNix.MkvExtract
                 hash = hash * 23 + TimecodesExtractionMode.GetHashCode();
                 hash = hash * 23 + CueExtractionMode.GetHashCode();
                 hash = hash * 23 + FilenamePatterns.GetHashCode();
+                hash = hash * 23 + DisableBomForTextFiles.GetHashCode();
                 hash = hash * 23 + OverwriteExistingFile.GetHashCode();
                 return hash;
             }


### PR DESCRIPTION
feat: Add option to disable BOM for text files (v96.0+) #31

#### PR Classification
New feature: adds an advanced option to control BOM output for extracted text files.

#### PR Summary
This pull request introduces an advanced setting to disable writing the BOM (Byte Order Mark) in extracted text files, supported for MKVToolNix v96.0 and above. The option is exposed in the UI and integrated throughout the extraction logic.
- gSettings.cs: Adds and persists the DisableBomForTextFiles property.
- frmOptions.Designer.cs/cs: Adds a new "Advanced Options" group with a checkbox for disabling BOM, and binds it to settings.
- gMKVExtract.cs: Passes the new setting through extraction parameters and appends --no-bom to mkvextract commands when appropriate.
- TrackParameter.cs, gMKVExtractSegmentsParameters.cs: Updates parameter classes to include the new property and related logic.
