### PR TITLE
feat: Add support for `raw` and `fullraw` track extraction modes

### DIFF
--- a/src/gMKVExtractGUI/Forms/frmMain2.cs
+++ b/src/gMKVExtractGUI/Forms/frmMain2.cs
@@ -1160,6 +1160,8 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
                             parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
+                            parameterList.UseRawExtractionMode = _Settings.UseRawExtractionMode;
+                            parameterList.UseFullRawExtractionMode = _Settings.UseFullRawExtractionMode;
                             break;
                         case FormMkvExtractionMode.Cue_Sheet:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1196,6 +1198,8 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
                             parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
+                            parameterList.UseRawExtractionMode = _Settings.UseRawExtractionMode;
+                            parameterList.UseFullRawExtractionMode = _Settings.UseFullRawExtractionMode;
                             break;
                         case FormMkvExtractionMode.Cues:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1218,6 +1222,8 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
                             parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
+                            parameterList.UseRawExtractionMode = _Settings.UseRawExtractionMode;
+                            parameterList.UseFullRawExtractionMode = _Settings.UseFullRawExtractionMode;
                             break;
                         case FormMkvExtractionMode.Tracks_And_Cues_And_Timecodes:
                             parameterList.MKVFile = infoSegment.Path;
@@ -1229,6 +1235,8 @@ Uncheck if you want to manually select an output directory for ALL extracted fil
                             parameterList.FilenamePatterns = GetFilenamePatterns();
                             parameterList.OverwriteExistingFile = chkOverwriteExistingFiles.Checked;
                             parameterList.DisableBomForTextFiles = _Settings.DisableBomForTextFiles;
+                            parameterList.UseRawExtractionMode = _Settings.UseRawExtractionMode;
+                            parameterList.UseFullRawExtractionMode = _Settings.UseFullRawExtractionMode;
                             break;
                     }
                     jobs.Add(new gMKVJob(extractionMode, txtMKVToolnixPath.Text, parameterList));

--- a/src/gMKVExtractGUI/Forms/frmOptions.Designer.cs
+++ b/src/gMKVExtractGUI/Forms/frmOptions.Designer.cs
@@ -61,7 +61,9 @@
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.grpAdvanced = new gMKVToolNix.gGroupBox();
+            this.chkRawMode = new System.Windows.Forms.CheckBox();
             this.chkTextFilesWithoutBom = new System.Windows.Forms.CheckBox();
+            this.chkFullRawMode = new System.Windows.Forms.CheckBox();
             this.tlpMain.SuspendLayout();
             this.grpTags.SuspendLayout();
             this.grpChapters.SuspendLayout();
@@ -455,6 +457,8 @@
             // 
             // grpAdvanced
             // 
+            this.grpAdvanced.Controls.Add(this.chkFullRawMode);
+            this.grpAdvanced.Controls.Add(this.chkRawMode);
             this.grpAdvanced.Controls.Add(this.chkTextFilesWithoutBom);
             this.grpAdvanced.Dock = System.Windows.Forms.DockStyle.Fill;
             this.grpAdvanced.Location = new System.Drawing.Point(3, 484);
@@ -463,6 +467,16 @@
             this.grpAdvanced.TabIndex = 8;
             this.grpAdvanced.TabStop = false;
             this.grpAdvanced.Text = "Advanced Options";
+            // 
+            // chkRawMode
+            // 
+            this.chkRawMode.AutoSize = true;
+            this.chkRawMode.Location = new System.Drawing.Point(225, 22);
+            this.chkRawMode.Name = "chkRawMode";
+            this.chkRawMode.Size = new System.Drawing.Size(128, 19);
+            this.chkRawMode.TabIndex = 1;
+            this.chkRawMode.Text = "Use `raw` extraction";
+            this.chkRawMode.UseVisualStyleBackColor = true;
             // 
             // chkTextFilesWithoutBom
             // 
@@ -473,6 +487,16 @@
             this.chkTextFilesWithoutBom.TabIndex = 0;
             this.chkTextFilesWithoutBom.Text = "Disable BOM to text files (v96.0+)";
             this.chkTextFilesWithoutBom.UseVisualStyleBackColor = true;
+            // 
+            // chkFullRawMode
+            // 
+            this.chkFullRawMode.AutoSize = true;
+            this.chkFullRawMode.Location = new System.Drawing.Point(369, 22);
+            this.chkFullRawMode.Name = "chkFullRawMode";
+            this.chkFullRawMode.Size = new System.Drawing.Size(148, 19);
+            this.chkFullRawMode.TabIndex = 2;
+            this.chkFullRawMode.Text = "Use `full raw` extraction";
+            this.chkFullRawMode.UseVisualStyleBackColor = true;
             // 
             // frmOptions
             // 
@@ -543,5 +567,7 @@
         private gTextBox txtTagsFilename;
         private gGroupBox grpAdvanced;
         private System.Windows.Forms.CheckBox chkTextFilesWithoutBom;
+        private System.Windows.Forms.CheckBox chkRawMode;
+        private System.Windows.Forms.CheckBox chkFullRawMode;
     }
 }

--- a/src/gMKVExtractGUI/Forms/frmOptions.cs
+++ b/src/gMKVExtractGUI/Forms/frmOptions.cs
@@ -90,6 +90,8 @@ Pressing the ""Default"" button you will reset the output filename format to its
             txtAttachmentsFilename.Text = _Settings.AttachmentFilenamePattern;
             txtTagsFilename.Text = _Settings.TagsFilenamePattern;
             chkTextFilesWithoutBom.Checked = _Settings.DisableBomForTextFiles;
+            chkRawMode.Checked = _Settings.UseRawExtractionMode;
+            chkFullRawMode.Checked = _Settings.UseFullRawExtractionMode;
         }
 
         private void UpdateSettings()
@@ -101,6 +103,8 @@ Pressing the ""Default"" button you will reset the output filename format to its
             _Settings.AttachmentFilenamePattern = txtAttachmentsFilename.Text;
             _Settings.TagsFilenamePattern = txtTagsFilename.Text;
             _Settings.DisableBomForTextFiles = chkTextFilesWithoutBom.Checked;
+            _Settings.UseRawExtractionMode = chkRawMode.Checked;
+            _Settings.UseFullRawExtractionMode = chkFullRawMode.Checked;
         }
 
         private ToolStripMenuItem GetToolstripMenuItem(string description, string placeholder, TextBox txtBox)

--- a/src/gMKVExtractGUI/gSettings.cs
+++ b/src/gMKVExtractGUI/gSettings.cs
@@ -138,6 +138,20 @@ namespace gMKVToolNix
             set { _DisableBomForTextFiles = value; }
         }
 
+        private bool _UseRawExtractionMode = false;
+        public bool UseRawExtractionMode
+        {
+            get { return _UseRawExtractionMode; }
+            set { _UseRawExtractionMode = value; }
+        }
+
+        private bool _UseFullRawExtractionMode = false;
+        public bool UseFullRawExtractionMode
+        {
+            get { return _UseFullRawExtractionMode; }
+            set { _UseFullRawExtractionMode = value; }
+        }
+        
         private string _VideoTrackFilenamePattern = "{FilenameNoExt}_track{TrackNumber}_[{Language}]";
         [DefaultValue("{FilenameNoExt}_track{TrackNumber}_[{Language}]")]
         public string VideoTrackFilenamePattern
@@ -587,6 +601,32 @@ namespace gMKVToolNix
                                 _DisableBomForTextFiles = false; // Default to false on error
                             }
                         }
+                        else if (line.StartsWith("UseRawExtractionMode:"))
+                        {
+                            try
+                            {
+                                _UseRawExtractionMode = bool.Parse(line.Substring(line.IndexOf(":") + 1));
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine(ex);
+                                gMKVLogger.Log(string.Format("Error reading UseRawExtractionMode! {0}", ex.Message));
+                                _UseRawExtractionMode = false; // Default to false on error
+                            }
+                        }
+                        else if (line.StartsWith("UseFullRawExtractionMode:"))
+                        {
+                            try
+                            {
+                                _UseFullRawExtractionMode = bool.Parse(line.Substring(line.IndexOf(":") + 1));
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine(ex);
+                                gMKVLogger.Log(string.Format("Error reading UseFullRawExtractionMode! {0}", ex.Message));
+                                _UseFullRawExtractionMode = false; // Default to false on error
+                            }
+                        }
                     }
                 }
                 gMKVLogger.Log("Finished loading settings!");
@@ -616,6 +656,8 @@ namespace gMKVToolNix
                 sw.WriteLine(string.Format("Disable Tooltips:{0}", _DisableTooltips));
                 sw.WriteLine(string.Format("DarkMode:{0}", _DarkMode));
                 sw.WriteLine(string.Format("DisableBomForTextFiles:{0}", _DisableBomForTextFiles));
+                sw.WriteLine(string.Format("UseRawExtractionMode:{0}", _UseRawExtractionMode));
+                sw.WriteLine(string.Format("UseFullRawExtractionMode:{0}", _UseFullRawExtractionMode));
 
                 sw.WriteLine(string.Format("VideoTrackFilenamePattern:{0}", _VideoTrackFilenamePattern));
                 sw.WriteLine(string.Format("AudioTrackFilenamePattern:{0}", _AudioTrackFilenamePattern));

--- a/src/gMKVToolNix/MkvExtract/TrackParameter.cs
+++ b/src/gMKVToolNix/MkvExtract/TrackParameter.cs
@@ -7,6 +7,8 @@
         public string TrackOutput { get; set; } = "";
         public bool WriteOutputToFile { get; set; } = false;
         public bool DisableBomForTextFiles { get; set; } = false;
+        public bool UseRawExtractionMode { get; set; } = false;
+        public bool UseFullRawExtractionMode { get; set; } = false;
         public string OutputFilename { get; set; } = "";
 
         public TrackParameter(
@@ -15,6 +17,8 @@
             string argTrackOutput,
             bool argWriteOutputToFile,
             bool argDisableBomForTextFiles,
+            bool argUseRawExtractionMode,
+            bool argUseFullRawExtractionMode,
             string argOutputFilename)
         {
             ExtractMode = argExtractMode;
@@ -22,6 +26,8 @@
             TrackOutput = argTrackOutput;
             WriteOutputToFile = argWriteOutputToFile;
             DisableBomForTextFiles = argDisableBomForTextFiles;
+            UseRawExtractionMode = argUseRawExtractionMode;
+            UseFullRawExtractionMode = argUseFullRawExtractionMode;
             OutputFilename = argOutputFilename;
         }
 

--- a/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtract.cs
@@ -76,7 +76,9 @@ namespace gMKVToolNix.MkvExtract
                     parameters.CueExtractionMode,
                     parameters.FilenamePatterns,
                     parameters.DisableBomForTextFiles,
-                    parameters.OverwriteExistingFile
+                    parameters.OverwriteExistingFile,
+                    parameters.UseRawExtractionMode,
+                    parameters.UseFullRawExtractionMode
                 );
             }
             catch (Exception ex)
@@ -95,6 +97,8 @@ namespace gMKVToolNix.MkvExtract
             , gMKVExtractFilenamePatterns argFilenamePatterns
             , bool argDisableBomForTextFiles
             , bool argOverwriteExistingFile
+            , bool argUseRawExtractionMode
+            , bool argUseFullRawExtractionMode
         )
         {
             Abort = false;
@@ -124,6 +128,8 @@ namespace gMKVToolNix.MkvExtract
                             argFilenamePatterns,
                             argDisableBomForTextFiles,
                             argOverwriteExistingFile,
+                            argUseRawExtractionMode,
+                            argUseFullRawExtractionMode,
                             _Version));
                 }
                 catch (Exception ex)
@@ -263,7 +269,9 @@ namespace gMKVToolNix.MkvExtract
                     CuesExtractionMode.NoCues,
                     parameters.FilenamePatterns,
                     parameters.DisableBomForTextFiles,
-                    parameters.OverwriteExistingFile
+                    parameters.OverwriteExistingFile,
+                    parameters.UseRawExtractionMode,
+                    parameters.UseFullRawExtractionMode
                 );
             }
             catch (Exception ex)
@@ -287,7 +295,9 @@ namespace gMKVToolNix.MkvExtract
                     CuesExtractionMode.OnlyCues,
                     parameters.FilenamePatterns,
                     parameters.DisableBomForTextFiles,
-                    parameters.OverwriteExistingFile
+                    parameters.OverwriteExistingFile,
+                    parameters.UseRawExtractionMode,
+                    parameters.UseFullRawExtractionMode
                 );
             }
             catch (Exception ex)
@@ -307,7 +317,9 @@ namespace gMKVToolNix.MkvExtract
                     parameters.OutputDirectory,
                     parameters.FilenamePatterns,
                     parameters.DisableBomForTextFiles,
-                    parameters.OverwriteExistingFile
+                    parameters.OverwriteExistingFile,
+                    parameters.UseRawExtractionMode,
+                    parameters.UseFullRawExtractionMode
                 );
             }
             catch (Exception ex)
@@ -321,7 +333,9 @@ namespace gMKVToolNix.MkvExtract
             string argOutputDirectory, 
             gMKVExtractFilenamePatterns argFilenamePatterns,
             bool argDisableBomForTextFiles,
-            bool argOverwriteExistingFile)
+            bool argOverwriteExistingFile,
+            bool argUseRawExtractionMode,
+            bool argUseFullRawExtractionMode)
         {
             Abort = false;
             AbortAll = false;
@@ -354,6 +368,8 @@ namespace gMKVToolNix.MkvExtract
                         , _Version.FileMajorPart >= 17 ? cueFile : ""
                         , _Version.FileMajorPart < 17
                         , argDisableBomForTextFiles
+                        , argUseRawExtractionMode
+                        , argUseFullRawExtractionMode
                         , _Version.FileMajorPart >= 17 ? "" : cueFile
                     )
                     , errors
@@ -391,7 +407,9 @@ namespace gMKVToolNix.MkvExtract
                     parameters.OutputDirectory,
                     parameters.FilenamePatterns,
                     parameters.DisableBomForTextFiles,
-                    parameters.OverwriteExistingFile
+                    parameters.OverwriteExistingFile,
+                    parameters.UseRawExtractionMode,
+                    parameters.UseFullRawExtractionMode
                 );
             }
             catch (Exception ex)
@@ -405,7 +423,9 @@ namespace gMKVToolNix.MkvExtract
             string argOutputDirectory, 
             gMKVExtractFilenamePatterns argFilenamePatterns,
             bool argDisableBomForTextFiles,
-            bool argOverwriteExistingFile)
+            bool argOverwriteExistingFile,
+            bool argUseRawExtractionMode,
+            bool argUseFullRawExtractionMode)
         {
             Abort = false;
             AbortAll = false;
@@ -438,6 +458,8 @@ namespace gMKVToolNix.MkvExtract
                         , _Version.FileMajorPart >= 17 ? tagsFile : ""
                         , _Version.FileMajorPart < 17
                         , argDisableBomForTextFiles
+                        , argUseRawExtractionMode
+                        , argUseFullRawExtractionMode
                         , _Version.FileMajorPart >= 17 ? "" : tagsFile
                     )
                     , errors
@@ -484,6 +506,8 @@ namespace gMKVToolNix.MkvExtract
             , gMKVExtractFilenamePatterns argFilenamePatterns
             , bool argDisableBomForTextFiles
             , bool argOverwriteExistingFile
+            , bool argUseRawExtractionMode
+            , bool argUseFullRawExtractionMode
             , gMKVVersion version)
         {
             // create the new parameter list type
@@ -510,6 +534,8 @@ namespace gMKVToolNix.MkvExtract
                         ),
                         false,
                         argDisableBomForTextFiles,
+                        argUseRawExtractionMode,
+                        argUseFullRawExtractionMode,
                         ""
                     ));
                 }
@@ -531,6 +557,8 @@ namespace gMKVToolNix.MkvExtract
                         ),
                         false,
                         argDisableBomForTextFiles,
+                        argUseRawExtractionMode,
+                        argUseFullRawExtractionMode,
                         ""
                     ));
                 }
@@ -566,6 +594,8 @@ namespace gMKVToolNix.MkvExtract
                         ),
                         false,
                         argDisableBomForTextFiles,
+                        argUseRawExtractionMode,
+                        argUseFullRawExtractionMode,
                         ""
                     ));
                 }
@@ -603,6 +633,8 @@ namespace gMKVToolNix.MkvExtract
                         ),
                         false,
                         argDisableBomForTextFiles,
+                        argUseRawExtractionMode,
+                        argUseFullRawExtractionMode,
                         ""
                     ));
                 }
@@ -648,6 +680,8 @@ namespace gMKVToolNix.MkvExtract
                         version.FileMajorPart >= 17 ? chapterFile : "",
                         version.FileMajorPart < 17,
                         argDisableBomForTextFiles,
+                        argUseRawExtractionMode,
+                        argUseFullRawExtractionMode,
                         version.FileMajorPart >= 17 ? "" : chapterFile
                     ));
                 }
@@ -749,6 +783,21 @@ namespace gMKVToolNix.MkvExtract
                 else
                 {
                     options = $"{parameters} --ui-language en {argParameter.Options}";
+                }
+
+                // Check for `full-raw` and `raw` extraction modes
+                // This is only valid for track extraction
+                // Full raw has precedence over raw
+                if (argParameter.ExtractMode == MkvExtractModes.tracks)
+                {
+                    if (argParameter.UseFullRawExtractionMode)
+                    {
+                        options = $"{options} --fullraw";
+                    }
+                    else if (argParameter.UseRawExtractionMode)
+                    {
+                        options = $"{options} --raw";
+                    }
                 }
 
                 // Since MKVToolNix v17.0, the syntax has changed

--- a/src/gMKVToolNix/MkvExtract/gMKVExtractSegmentsParameters.cs
+++ b/src/gMKVToolNix/MkvExtract/gMKVExtractSegmentsParameters.cs
@@ -15,6 +15,8 @@ namespace gMKVToolNix.MkvExtract
         public CuesExtractionMode CueExtractionMode { get; set; }
         public gMKVExtractFilenamePatterns FilenamePatterns { get; set; }
         public bool DisableBomForTextFiles { get; set; } = false;
+        public bool UseRawExtractionMode { get; set; } = false;
+        public bool UseFullRawExtractionMode { get; set; } = false;
         public bool OverwriteExistingFile { get; set; } = false;
 
         public override bool Equals(object oth)
@@ -36,6 +38,8 @@ namespace gMKVToolNix.MkvExtract
                 && CueExtractionMode == other.CueExtractionMode
                 && FilenamePatterns.Equals(other.FilenamePatterns)
                 && DisableBomForTextFiles.Equals(other.DisableBomForTextFiles)
+                && UseRawExtractionMode.Equals(other.UseRawExtractionMode)
+                && UseFullRawExtractionMode.Equals(other.UseFullRawExtractionMode)
                 && OverwriteExistingFile.Equals(other.OverwriteExistingFile)
             ;
         }
@@ -53,6 +57,8 @@ namespace gMKVToolNix.MkvExtract
                 hash = hash * 23 + CueExtractionMode.GetHashCode();
                 hash = hash * 23 + FilenamePatterns.GetHashCode();
                 hash = hash * 23 + DisableBomForTextFiles.GetHashCode();
+                hash = hash * 23 + UseRawExtractionMode.GetHashCode();
+                hash = hash * 23 + UseFullRawExtractionMode.GetHashCode();
                 hash = hash * 23 + OverwriteExistingFile.GetHashCode();
                 return hash;
             }


### PR DESCRIPTION
feat: Add support for `raw` and `fullraw` track extraction modes

#### PR Classification
New feature: Adds advanced extraction options for MKV track extraction.

#### PR Summary
This pull request introduces support for "raw" and "full raw" extraction modes in MKV track extraction, including UI, settings, and extraction logic updates.
- gSettings.cs: Adds and persists UseRawExtractionMode and UseFullRawExtractionMode properties.
- frmOptions(.Designer).cs: Adds checkboxes for the new options and syncs them with settings.
- gMKVExtractSegmentsParameters and TrackParameter: Propagate the new options through the extraction pipeline.
- gMKVExtract.cs: Updates extraction logic to append --raw or --fullraw to mkvextract commands as appropriate.
- Updates equality and hash code logic in gMKVExtractSegmentsParameters to include the new options.
